### PR TITLE
Libtest json output serde

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2421,6 +2421,8 @@ name = "test"
 version = "0.0.0"
 dependencies = [
  "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.0.0",
 ]
 

--- a/src/libtest/Cargo.toml
+++ b/src/libtest/Cargo.toml
@@ -11,3 +11,5 @@ crate-type = ["dylib", "rlib"]
 [dependencies]
 getopts = "0.2"
 term = { path = "../libterm" }
+serde = "1.0.23"
+serde_json = "1.0.7"

--- a/src/libtest/formatters.rs
+++ b/src/libtest/formatters.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 use super::*;
+use serde_json::Value as Json;
 
 pub(crate) trait OutputFormatter {
     fn write_run_start(&mut self, test_count: usize) -> io::Result<()>;
@@ -289,52 +290,19 @@ impl<T: Write> JsonFormatter<T> {
         Self { out }
     }
 
-    fn write_message(&mut self, s: &str) -> io::Result<()> {
-        assert!(!s.contains('\n'));
-
-        self.out.write_all(s.as_ref())?;
+    fn write_message(&mut self, s: &Json) -> io::Result<()> {
+        serde_json::to_writer(&mut self.out, s).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
         self.out.write_all(b"\n")
-    }
-
-    fn write_event(
-        &mut self,
-        ty: &str,
-        name: &str,
-        evt: &str,
-        extra: Option<String>,
-    ) -> io::Result<()> {
-        if let Some(extras) = extra {
-            self.write_message(&*format!(
-                r#"{{ "type": "{}", "name": "{}", "event": "{}", {} }}"#,
-                ty,
-                name,
-                evt,
-                extras
-            ))
-        } else {
-            self.write_message(&*format!(
-                r#"{{ "type": "{}", "name": "{}", "event": "{}" }}"#,
-                ty,
-                name,
-                evt
-            ))
-        }
     }
 }
 
 impl<T: Write> OutputFormatter for JsonFormatter<T> {
     fn write_run_start(&mut self, test_count: usize) -> io::Result<()> {
-        self.write_message(&*format!(
-            r#"{{ "type": "suite", "event": "started", "test_count": "{}" }}"#,
-            test_count
-        ))
+        self.write_message(&json!({ "type": "suite", "event": "started", "test_count": test_count, }))
     }
 
     fn write_test_start(&mut self, desc: &TestDesc) -> io::Result<()> {
-        self.write_message(&*format!(
-            r#"{{ "type": "test", "event": "started", "name": "{}" }}"#,
-            desc.name
-        ))
+        self.write_message(&json!({ "type": "test", "event": "started", "name": desc.name.as_slice(), }))
     }
 
     fn write_result(
@@ -344,36 +312,33 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
         stdout: &[u8],
     ) -> io::Result<()> {
         match *result {
-            TrOk => self.write_event("test", desc.name.as_slice(), "ok", None),
-
-            TrFailed => {
-                let extra_data = if stdout.len() > 0 {
-                    Some(format!(
-                        r#""stdout": "{}""#,
-                        EscapedString(String::from_utf8_lossy(stdout))
-                    ))
-                } else {
-                    None
-                };
-
-                self.write_event("test", desc.name.as_slice(), "failed", extra_data)
-            }
-
-            TrFailedMsg(ref m) => {
-                self.write_event(
-                    "test",
-                    desc.name.as_slice(),
-                    "failed",
-                    Some(format!(r#""message": "{}""#, EscapedString(m))),
-                )
-            }
-
-            TrIgnored => self.write_event("test", desc.name.as_slice(), "ignored", None),
-
-            TrAllowedFail => {
-                self.write_event("test", desc.name.as_slice(), "allowed_failure", None)
-            }
-
+            TrOk => self.write_message(&json!({
+                "type": "test",
+                "name": desc.name.as_slice(),
+                "event": "ok",
+            })),
+            TrFailed => self.write_message(&json!({
+                "type": "test",
+                "name": desc.name.as_slice(),
+                "event": "failed",
+                "stdout": String::from_utf8_lossy(stdout),
+            })),
+            TrFailedMsg(ref m) => self.write_message(&json!({
+                "type": "test",
+                "name": desc.name.as_slice(),
+                "event": "failed",
+                "message": m,
+            })),
+            TrIgnored => self.write_message(&json!({
+                "type": "test",
+                "name": desc.name.as_slice(),
+                "event": "ignored",
+            })),
+            TrAllowedFail => self.write_message(&json!({
+                "type": "test",
+                "name": desc.name.as_slice(),
+                "event": "allowed_failure",
+            })),
             TrBench(ref bs) => {
                 let median = bs.ns_iter_summ.median as usize;
                 let deviation = (bs.ns_iter_summ.max - bs.ns_iter_summ.min) as usize;
@@ -383,117 +348,37 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
                 } else {
                     format!(r#", "mib_per_second": {}"#, bs.mb_s)
                 };
-
-                let line = format!(
-                    "{{ \"type\": \"bench\", \
-                                \"name\": \"{}\", \
-                                \"median\": {}, \
-                                \"deviation\": {}{} }}",
-                    desc.name,
-                    median,
-                    deviation,
-                    mbps
-                );
-
-                self.write_message(&*line)
+                self.write_message(&json!({
+                    "type": "bench",
+                    "name": desc.name.as_slice(),
+                    "median": median,
+                    "deviation": format!("{}{}", deviation, mbps),
+                }))
             }
         }
     }
 
     fn write_timeout(&mut self, desc: &TestDesc) -> io::Result<()> {
-        self.write_message(&*format!(
-            r#"{{ "type": "test", "event": "timeout", "name": "{}" }}"#,
-            desc.name
-        ))
+        self.write_message(&json!({
+            "type": "test",
+            "name": desc.name.as_slice(),
+            "event": "timeout",
+        }))
     }
 
     fn write_run_finish(&mut self, state: &ConsoleTestState) -> io::Result<bool> {
-
-        self.write_message(&*format!(
-            "{{ \"type\": \"suite\", \
-            \"event\": \"{}\", \
-            \"passed\": {}, \
-            \"failed\": {}, \
-            \"allowed_fail\": {}, \
-            \"ignored\": {}, \
-            \"measured\": {}, \
-            \"filtered_out\": \"{}\" }}",
-            if state.failed == 0 { "ok" } else { "failed" },
-            state.passed,
-            state.failed + state.allowed_fail,
-            state.allowed_fail,
-            state.ignored,
-            state.measured,
-            state.filtered_out
-        ))?;
+        self.write_message(&json!({
+            "type": "suite",
+            "event": if state.failed == 0 { "ok" } else { "failed" },
+            "passed": state.passed,
+            "failed": state.failed + state.allowed_fail,
+            "allowed_fail": state.allowed_fail,
+            "ignored": state.ignored,
+            "measured": state.measured,
+            "filtered_out": state.filtered_out,
+        }))?;
 
         Ok(state.failed == 0)
     }
 }
 
-/// A formatting utility used to print strings with characters in need of escaping.
-/// Base code taken form `libserialize::json::escape_str`
-struct EscapedString<S: AsRef<str>>(S);
-
-impl<S: AsRef<str>> ::std::fmt::Display for EscapedString<S> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        let mut start = 0;
-
-        for (i, byte) in self.0.as_ref().bytes().enumerate() {
-            let escaped = match byte {
-                b'"' => "\\\"",
-                b'\\' => "\\\\",
-                b'\x00' => "\\u0000",
-                b'\x01' => "\\u0001",
-                b'\x02' => "\\u0002",
-                b'\x03' => "\\u0003",
-                b'\x04' => "\\u0004",
-                b'\x05' => "\\u0005",
-                b'\x06' => "\\u0006",
-                b'\x07' => "\\u0007",
-                b'\x08' => "\\b",
-                b'\t' => "\\t",
-                b'\n' => "\\n",
-                b'\x0b' => "\\u000b",
-                b'\x0c' => "\\f",
-                b'\r' => "\\r",
-                b'\x0e' => "\\u000e",
-                b'\x0f' => "\\u000f",
-                b'\x10' => "\\u0010",
-                b'\x11' => "\\u0011",
-                b'\x12' => "\\u0012",
-                b'\x13' => "\\u0013",
-                b'\x14' => "\\u0014",
-                b'\x15' => "\\u0015",
-                b'\x16' => "\\u0016",
-                b'\x17' => "\\u0017",
-                b'\x18' => "\\u0018",
-                b'\x19' => "\\u0019",
-                b'\x1a' => "\\u001a",
-                b'\x1b' => "\\u001b",
-                b'\x1c' => "\\u001c",
-                b'\x1d' => "\\u001d",
-                b'\x1e' => "\\u001e",
-                b'\x1f' => "\\u001f",
-                b'\x7f' => "\\u007f",
-                _ => {
-                    continue;
-                }
-            };
-
-            if start < i {
-                f.write_str(&self.0.as_ref()[start..i])?;
-            }
-
-            f.write_str(escaped)?;
-
-            start = i + 1;
-        }
-
-        if start != self.0.as_ref().len() {
-            f.write_str(&self.0.as_ref()[start..])?;
-        }
-
-        Ok(())
-    }
-}

--- a/src/libtest/formatters.rs
+++ b/src/libtest/formatters.rs
@@ -302,7 +302,7 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
     }
 
     fn write_test_start(&mut self, desc: &TestDesc) -> io::Result<()> {
-        self.write_message(&json!({ "type": "test", "event": "started", "name": desc.name.as_slice(), }))
+        self.write_message(&json!({ "type": "test", "event": "started", "name": desc.name.as_str(), }))
     }
 
     fn write_result(
@@ -314,29 +314,29 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
         match *result {
             TrOk => self.write_message(&json!({
                 "type": "test",
-                "name": desc.name.as_slice(),
+                "name": desc.name.as_str(),
                 "event": "ok",
             })),
             TrFailed => self.write_message(&json!({
                 "type": "test",
-                "name": desc.name.as_slice(),
+                "name": desc.name.as_str(),
                 "event": "failed",
                 "stdout": String::from_utf8_lossy(stdout),
             })),
             TrFailedMsg(ref m) => self.write_message(&json!({
                 "type": "test",
-                "name": desc.name.as_slice(),
+                "name": desc.name.as_str(),
                 "event": "failed",
                 "message": m,
             })),
             TrIgnored => self.write_message(&json!({
                 "type": "test",
-                "name": desc.name.as_slice(),
+                "name": desc.name.as_str(),
                 "event": "ignored",
             })),
             TrAllowedFail => self.write_message(&json!({
                 "type": "test",
-                "name": desc.name.as_slice(),
+                "name": desc.name.as_str(),
                 "event": "allowed_failure",
             })),
             TrBench(ref bs) => {
@@ -350,7 +350,7 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
                 };
                 self.write_message(&json!({
                     "type": "bench",
-                    "name": desc.name.as_slice(),
+                    "name": desc.name.as_str(),
                     "median": median,
                     "deviation": format!("{}{}", deviation, mbps),
                 }))
@@ -361,7 +361,7 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
     fn write_timeout(&mut self, desc: &TestDesc) -> io::Result<()> {
         self.write_message(&json!({
             "type": "test",
-            "name": desc.name.as_slice(),
+            "name": desc.name.as_str(),
             "event": "timeout",
         }))
     }

--- a/src/libtest/formatters/human.rs
+++ b/src/libtest/formatters/human.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,21 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use super::*;
-use serde_json::Value as Json;
-
-pub(crate) trait OutputFormatter {
-    fn write_run_start(&mut self, test_count: usize) -> io::Result<()>;
-    fn write_test_start(&mut self, desc: &TestDesc) -> io::Result<()>;
-    fn write_timeout(&mut self, desc: &TestDesc) -> io::Result<()>;
-    fn write_result(
-        &mut self,
-        desc: &TestDesc,
-        result: &TestResult,
-        stdout: &[u8],
-    ) -> io::Result<()>;
-    fn write_run_finish(&mut self, state: &ConsoleTestState) -> io::Result<bool>;
-}
+use ::*;
 
 pub(crate) struct HumanFormatter<T> {
     out: OutputLocation<T>,
@@ -280,105 +266,3 @@ impl<T: Write> OutputFormatter for HumanFormatter<T> {
         Ok(success)
     }
 }
-
-pub(crate) struct JsonFormatter<T> {
-    out: OutputLocation<T>,
-}
-
-impl<T: Write> JsonFormatter<T> {
-    pub fn new(out: OutputLocation<T>) -> Self {
-        Self { out }
-    }
-
-    fn write_message(&mut self, s: &Json) -> io::Result<()> {
-        serde_json::to_writer(&mut self.out, s).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-        self.out.write_all(b"\n")
-    }
-}
-
-impl<T: Write> OutputFormatter for JsonFormatter<T> {
-    fn write_run_start(&mut self, test_count: usize) -> io::Result<()> {
-        self.write_message(&json!({ "type": "suite", "event": "started", "test_count": test_count, }))
-    }
-
-    fn write_test_start(&mut self, desc: &TestDesc) -> io::Result<()> {
-        self.write_message(&json!({ "type": "test", "event": "started", "name": desc.name.as_str(), }))
-    }
-
-    fn write_result(
-        &mut self,
-        desc: &TestDesc,
-        result: &TestResult,
-        stdout: &[u8],
-    ) -> io::Result<()> {
-        match *result {
-            TrOk => self.write_message(&json!({
-                "type": "test",
-                "name": desc.name.as_str(),
-                "event": "ok",
-            })),
-            TrFailed => self.write_message(&json!({
-                "type": "test",
-                "name": desc.name.as_str(),
-                "event": "failed",
-                "stdout": String::from_utf8_lossy(stdout),
-            })),
-            TrFailedMsg(ref m) => self.write_message(&json!({
-                "type": "test",
-                "name": desc.name.as_str(),
-                "event": "failed",
-                "message": m,
-            })),
-            TrIgnored => self.write_message(&json!({
-                "type": "test",
-                "name": desc.name.as_str(),
-                "event": "ignored",
-            })),
-            TrAllowedFail => self.write_message(&json!({
-                "type": "test",
-                "name": desc.name.as_str(),
-                "event": "allowed_failure",
-            })),
-            TrBench(ref bs) => {
-                let median = bs.ns_iter_summ.median as usize;
-                let deviation = (bs.ns_iter_summ.max - bs.ns_iter_summ.min) as usize;
-
-                let mbps = if bs.mb_s == 0 {
-                    "".into()
-                } else {
-                    format!(r#", "mib_per_second": {}"#, bs.mb_s)
-                };
-                self.write_message(&json!({
-                    "type": "bench",
-                    "name": desc.name.as_str(),
-                    "median": median,
-                    "deviation": format!("{}{}", deviation, mbps),
-                }))
-            }
-        }
-    }
-
-    fn write_timeout(&mut self, desc: &TestDesc) -> io::Result<()> {
-        self.write_message(&json!({
-            "type": "test",
-            "name": desc.name.as_str(),
-            "event": "timeout",
-        }))
-    }
-
-    fn write_run_finish(&mut self, state: &ConsoleTestState) -> io::Result<bool> {
-        self.write_message(&json!({
-            "type": "suite",
-            "event": if state.failed == 0 { "ok" } else { "failed" },
-            "passed": state.passed,
-            "failed": state.failed + state.allowed_fail,
-            "allowed_fail": state.allowed_fail,
-            "ignored": state.ignored,
-            "measured": state.measured,
-            "filtered_out": state.filtered_out,
-        }))?;
-
-        Ok(state.failed == 0)
-    }
-}
-

--- a/src/libtest/formatters/json.rs
+++ b/src/libtest/formatters/json.rs
@@ -1,0 +1,115 @@
+// Copyright 2012-2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+use serde_json::Value as Json;
+
+use ::*;
+
+pub(crate) struct JsonFormatter<T> {
+    out: OutputLocation<T>,
+}
+
+impl<T: Write> JsonFormatter<T> {
+    pub fn new(out: OutputLocation<T>) -> Self {
+        Self { out }
+    }
+
+    fn write_message(&mut self, s: &Json) -> io::Result<()> {
+        serde_json::to_writer(&mut self.out, s).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        self.out.write_all(b"\n")
+    }
+}
+
+impl<T: Write> OutputFormatter for JsonFormatter<T> {
+    fn write_run_start(&mut self, test_count: usize) -> io::Result<()> {
+        self.write_message(&json!({ "type": "suite", "event": "started", "test_count": test_count, }))
+    }
+
+    fn write_test_start(&mut self, desc: &TestDesc) -> io::Result<()> {
+        self.write_message(&json!({ "type": "test", "event": "started", "name": desc.name.as_str(), }))
+    }
+
+    fn write_result(
+        &mut self,
+        desc: &TestDesc,
+        result: &TestResult,
+        stdout: &[u8],
+    ) -> io::Result<()> {
+        match *result {
+            TrOk => self.write_message(&json!({
+                "type": "test",
+                "name": desc.name.as_str(),
+                "event": "ok",
+            })),
+            TrFailed => self.write_message(&json!({
+                "type": "test",
+                "name": desc.name.as_str(),
+                "event": "failed",
+                "stdout": String::from_utf8_lossy(stdout),
+            })),
+            TrFailedMsg(ref m) => self.write_message(&json!({
+                "type": "test",
+                "name": desc.name.as_str(),
+                "event": "failed",
+                "message": m,
+            })),
+            TrIgnored => self.write_message(&json!({
+                "type": "test",
+                "name": desc.name.as_str(),
+                "event": "ignored",
+            })),
+            TrAllowedFail => self.write_message(&json!({
+                "type": "test",
+                "name": desc.name.as_str(),
+                "event": "allowed_failure",
+            })),
+            TrBench(ref bs) => {
+                let median = bs.ns_iter_summ.median as usize;
+                let deviation = (bs.ns_iter_summ.max - bs.ns_iter_summ.min) as usize;
+
+                let mbps = if bs.mb_s == 0 {
+                    "".into()
+                } else {
+                    format!(r#", "mib_per_second": {}"#, bs.mb_s)
+                };
+                self.write_message(&json!({
+                    "type": "bench",
+                    "name": desc.name.as_str(),
+                    "median": median,
+                    "deviation": format!("{}{}", deviation, mbps),
+                }))
+            }
+        }
+    }
+
+    fn write_timeout(&mut self, desc: &TestDesc) -> io::Result<()> {
+        self.write_message(&json!({
+            "type": "test",
+            "name": desc.name.as_str(),
+            "event": "timeout",
+        }))
+    }
+
+    fn write_run_finish(&mut self, state: &ConsoleTestState) -> io::Result<bool> {
+        self.write_message(&json!({
+            "type": "suite",
+            "event": if state.failed == 0 { "ok" } else { "failed" },
+            "passed": state.passed,
+            "failed": state.failed + state.allowed_fail,
+            "allowed_fail": state.allowed_fail,
+            "ignored": state.ignored,
+            "measured": state.measured,
+            "filtered_out": state.filtered_out,
+        }))?;
+
+        Ok(state.failed == 0)
+    }
+}

--- a/src/libtest/formatters/mod.rs
+++ b/src/libtest/formatters/mod.rs
@@ -1,0 +1,32 @@
+// Copyright 2012-2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+
+use super::{TestDesc, TestResult, ConsoleTestState};
+
+mod human;
+mod json;
+
+pub(crate) use self::human::HumanFormatter;
+pub(crate) use self::json::JsonFormatter;
+
+pub(crate) trait OutputFormatter {
+    fn write_run_start(&mut self, test_count: usize) -> io::Result<()>;
+    fn write_test_start(&mut self, desc: &TestDesc) -> io::Result<()>;
+    fn write_timeout(&mut self, desc: &TestDesc) -> io::Result<()>;
+    fn write_result(
+        &mut self,
+        desc: &TestDesc,
+        result: &TestResult,
+        stdout: &[u8],
+    ) -> io::Result<()>;
+    fn write_run_finish(&mut self, state: &ConsoleTestState) -> io::Result<bool>;
+}

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2012-2017 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -100,6 +100,7 @@ pub enum TestName {
     DynTestName(String),
     AlignedTestName(Cow<'static, str>, NamePadding),
 }
+
 impl TestName {
     fn as_str(&self) -> &str {
         match *self {
@@ -126,6 +127,7 @@ impl TestName {
         TestName::AlignedTestName(name, padding)
     }
 }
+
 impl fmt::Display for TestName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(self.as_str(), f)

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -101,7 +101,7 @@ pub enum TestName {
     AlignedTestName(Cow<'static, str>, NamePadding),
 }
 impl TestName {
-    fn as_slice(&self) -> &str {
+    fn as_str(&self) -> &str {
         match *self {
             StaticTestName(s) => s,
             DynTestName(ref s) => s,
@@ -128,7 +128,7 @@ impl TestName {
 }
 impl fmt::Display for TestName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(self.as_slice(), f)
+        fmt::Display::fmt(self.as_str(), f)
     }
 }
 
@@ -140,7 +140,7 @@ pub enum NamePadding {
 
 impl TestDesc {
     fn padded_name(&self, column_count: usize, align: NamePadding) -> String {
-        let mut name = String::from(self.name.as_slice());
+        let mut name = String::from(self.name.as_str());
         let fill = column_count.saturating_sub(name.len());
         let pad = repeat(" ").take(fill).collect::<String>();
         match align {
@@ -880,7 +880,7 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Resu
                     TrAllowedFail => st.allowed_fail += 1,
                     TrBench(bs) => {
                         st.metrics.insert_metric(
-                            test.name.as_slice(),
+                            test.name.as_str(),
                             bs.ns_iter_summ.median,
                             bs.ns_iter_summ.max - bs.ns_iter_summ.min,
                         );
@@ -910,7 +910,7 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Resu
     let max_name_len = tests
         .iter()
         .max_by_key(|t| len_if_padded(*t))
-        .map(|t| t.desc.name.as_slice().len())
+        .map(|t| t.desc.name.as_str().len())
         .unwrap_or(0);
 
     let is_multithreaded = match opts.test_threads {
@@ -939,7 +939,7 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Resu
     fn len_if_padded(t: &TestDescAndFn) -> usize {
         match t.testfn.padding() {
             PadNone => 0,
-            PadOnRight => t.desc.name.as_slice().len(),
+            PadOnRight => t.desc.name.as_str().len(),
         }
     }
 
@@ -1301,9 +1301,9 @@ pub fn filter_tests(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> Vec<TestDescA
             filtered
                 .into_iter()
                 .filter(|test| if opts.filter_exact {
-                    test.desc.name.as_slice() == &filter[..]
+                    test.desc.name.as_str() == &filter[..]
                 } else {
-                    test.desc.name.as_slice().contains(&filter[..])
+                    test.desc.name.as_str().contains(&filter[..])
                 })
                 .collect()
         }
@@ -1314,9 +1314,9 @@ pub fn filter_tests(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> Vec<TestDescA
         .into_iter()
         .filter(|t| {
             !opts.skip.iter().any(|sf| if opts.filter_exact {
-                t.desc.name.as_slice() == &sf[..]
+                t.desc.name.as_str() == &sf[..]
             } else {
-                t.desc.name.as_slice().contains(&sf[..])
+                t.desc.name.as_str().contains(&sf[..])
             })
         })
         .collect();
@@ -1344,7 +1344,7 @@ pub fn filter_tests(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> Vec<TestDescA
 
     // Sort the tests alphabetically
     filtered.sort_by(|t1, t2| {
-        t1.desc.name.as_slice().cmp(t2.desc.name.as_slice())
+        t1.desc.name.as_str().cmp(t2.desc.name.as_str())
     });
 
     filtered
@@ -1449,7 +1449,7 @@ pub fn run_test(
         // level.
         let supports_threads = !cfg!(target_os = "emscripten") && !cfg!(target_arch = "wasm32");
         if supports_threads {
-            let cfg = thread::Builder::new().name(name.as_slice().to_owned());
+            let cfg = thread::Builder::new().name(name.as_str().to_owned());
             cfg.spawn(runtest).unwrap();
         } else {
             runtest();

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -45,6 +45,8 @@ extern crate term;
 #[cfg(unix)]
 extern crate libc;
 extern crate panic_unwind;
+extern crate serde;
+#[macro_use] extern crate serde_json;
 
 pub use self::TestFn::*;
 pub use self::ColorConfig::*;


### PR DESCRIPTION
- Use serde_json

   Instead of implementing a JSON writer ourselves, incl. string escaping,
let's use serde's json crate which is proven to work very well, and
whose macro makes the code quite concise.

- Rename TestName::as_slice

   While it's not false that it return a slice, it is more precise to say
it returns a string slice.

- Split formatters into modules

   The usage of `::*` is a bit ugly, but easy to fix when the code is less
often changing.